### PR TITLE
Do not show Loading... text and try restart MAPI on error

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,6 +29,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install streamdeck-sdk streamdeck-sdk-cli
+
+      - name: Create venv
+        run: |
+          python -m venv com.mcczarny.outlookunreadcounter.sdPlugin/code/venv
+          com.mcczarny.outlookunreadcounter.sdPlugin/code/venv/Scripts/pip install --upgrade pip
+          com.mcczarny.outlookunreadcounter.sdPlugin/code/venv/Scripts/pip install -r com.mcczarny.outlookunreadcounter.sdPlugin/code/requirements.txt
           
       - name: Build Stream Deck plugin
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ com.mcczarny.outlookunreadcounter.sdPlugin/logs
 *.pyc
 releases
 venv
+.venv

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/code/main.py
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/code/main.py
@@ -43,7 +43,6 @@ class UnreadCounter(Action):
 
     def update_unread_count(self, outlook, context: str, account: str):
         logger.debug(f"update_unread_count: {context} account: {account}")
-        self.set_title(context=context, title=f"Loading...")
         unread_count = "?"
         if account:
             logger.debug(f"account: {account}")
@@ -83,10 +82,13 @@ class UnreadCounter(Action):
                 try:
                     logger.debug(f"run_monitoring: {context} {account}")
                     self.update_unread_count(outlook=self.monitor_outlook, context=context, account=account)
+                except win32com.client.pywintypes.com_error as err:
+                    logger.exception(err)
+                    logger.debug(f"run_monitoring: {context} {account} - restarting monitoring")
+                    self.monitor_outlook = win32com.client.Dispatch("Outlook.Application").GetNamespace("MAPI")
                 except Exception as err:
                     logger.exception(err)
             self.wake_event.clear()
-
 
 if __name__ == "__main__":
     unread_counter = UnreadCounter()

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json
@@ -30,7 +30,7 @@
   "Description": "Windows Outlook unread messages counter.",
   "Icon": "assets/unread_counter/envelope_open_icon",
   "Name": "Outlook Unread Counter",
-  "Version": "0.0.68",
+  "Version": "0.0.70",
   "SDKVersion": 2,
   "OS": [
     {


### PR DESCRIPTION
- Do not show "Loading..." text before getting unread count to not flicker the tile
- If Outlook tray app is closed, try to restart MAPI
- create venv to include in the plugin to have compatible python