### PR TITLE
Add flag to animate extra info rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ com.mcczarny.outlookunreadcounter.sdPlugin/logs
 releases
 venv
 .venv
+logs

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Increment the version number in the plugin's manifest.json file and run the build process
+MANIFEST_FILE="./com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json"
+VERSION_NUMBER=$(grep -oP '"Version": "\K[^"]*' $MANIFEST_FILE)
+echo "Current version number: $VERSION_NUMBER"
+echo "Incrementing version number..."
+# Increment the version number
+NEW_VERSION_NUMBER=$(echo $VERSION_NUMBER | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
+echo "New version number: $NEW_VERSION_NUMBER"
+# Replace the version number in the manifest.json file
+sed -i "s/$VERSION_NUMBER/$NEW_VERSION_NUMBER/g" $MANIFEST_FILE
+
+# Run the build process
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+"${SCRIPT_DIR}/.venv/Scripts/streamdeck_sdk.exe" build -i com.mcczarny.outlookunreadcounter.sdPlugin

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/assets/unread_counter/envelope_closed_icon.svg
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/assets/unread_counter/envelope_closed_icon.svg
@@ -8,52 +8,38 @@
    version="1.1"
    id="svg5"
    inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
-   sodipodi:docname="envelope-closed.svg"
+   sodipodi:docname="envelope_closed_icon.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <sodipodi:namedview
      id="namedview7"
-     pagecolor="#ffffff"
+     pagecolor="#000000"
      bordercolor="#000000"
      borderopacity="0.25"
      inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
+     inkscape:pageopacity="0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="false"
      inkscape:zoom="1.0255231"
-     inkscape:cx="-24.377803"
-     inkscape:cy="292.04609"
+     inkscape:cx="-45.830269"
+     inkscape:cy="293.02119"
      inkscape:window-width="1920"
      inkscape:window-height="1001"
      inkscape:window-x="-9"
      inkscape:window-y="916"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="layer1-4" />
   <defs
      id="defs2" />
   <g
      inkscape:label="Warstwa 1"
      inkscape:groupmode="layer"
-     id="layer1">
-    <g
-       inkscape:groupmode="layer"
-       id="layer2-8"
-       inkscape:label="background"
-       transform="translate(0.60000002,0.60000002)"
-       style="fill:#000000;stroke:none">
-      <rect
-         style="display:none;fill:#000000;stroke:none;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:14.5;stroke-dasharray:none"
-         id="rect2185-3"
-         width="43.260715"
-         height="43.740513"
-         x="75.031555"
-         y="104.75948"
-         ry="0" />
-    </g>
+     id="layer1"
+     style="display:none">
     <path
        id="path1929"
        style="fill:none;stroke:#ffffff;stroke-width:8.417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:14.5;stroke-dasharray:none"
@@ -88,6 +74,24 @@
        style="fill:none;stroke:#ffffff;stroke-width:8.417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:14.5;stroke-dasharray:none"
        d="M 102.0764,59.916932 66.145619,90.035888 93.860785,107.65437"
        id="path2034-4" />
+  </g>
+  <g
+     inkscape:label="combined"
+     inkscape:groupmode="layer"
+     id="layer1-4">
+    <path
+       id="path1929-6-9"
+       style="display:none;fill:none;stroke:#ffffff;stroke-width:8.417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:14.5;stroke-dasharray:none"
+       d="M 102.0764,59.916932 66.145224,24.636899 30.215086,59.916932"
+       inkscape:export-filename="envelope.png"
+       inkscape:export-xdpi="83.620415"
+       inkscape:export-ydpi="83.620415"
+       sodipodi:nodetypes="ccc"
+       inkscape:label="open" />
+    <path
+       id="path2034-4-5"
+       style="fill:none;stroke:#ffffff;stroke-width:8.417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:14.5;stroke-dasharray:none;opacity:0.4989339"
+       d="M 102.0764,59.916932 66.145619,90.035888 93.860785,107.65437 M 30.214818,59.916932 66.145619,90.035888 38.430423,107.65437 M 102.0764,98.835842 v -38.91891 c -0.60438,-5.422046 -3.621597,-8.037516 -8.215124,-8.818916 H 66.146262 38.43128 c -4.593527,0.7814 -7.611814,3.39687 -8.216194,8.818916 v 38.91891 m 9e-5,-38.91894 v 38.918909 c 0.604382,5.422049 3.621597,8.037519 8.215124,8.818919 h 27.715014 27.714982 c 4.593527,-0.7814 7.611814,-3.39687 8.216194,-8.818919 V 59.916902" />
   </g>
   <g
      inkscape:groupmode="layer"

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/code/context_data.py
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/code/context_data.py
@@ -1,0 +1,25 @@
+from enum import Enum
+from dataclasses import dataclass
+
+class ExtraInfoStates(str, Enum):
+    NONE = "None"
+    SENDER = "Sender"
+    SUBJECT = "Subject"
+    BOTH = "Both"
+
+@dataclass
+class ContextData:
+    account: str
+    extra_info: ExtraInfoStates = ExtraInfoStates.NONE
+    animated: bool = False
+    animation_index: int = 1
+
+    def __post_init__(self):
+        if not isinstance(self.account, str) or not self.account:
+            raise ValueError("Account must be a non-empty string")
+        if not isinstance(self.extra_info, ExtraInfoStates):
+            raise ValueError("Extra info must be an instance of ExtraInfoStates")
+        if not isinstance(self.animated, bool):
+            raise ValueError("Animated must be a boolean")
+        if not isinstance(self.animation_index, int) or self.animation_index < 1:
+            raise ValueError("Animation index must be a positive integer")

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/code/context_data.py
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/code/context_data.py
@@ -1,5 +1,8 @@
 from enum import Enum
 from dataclasses import dataclass
+from tile_visualizer import TileVisualizer, SimpleVisualizer, ExtraInfoVisualizer, AnimatedExtraInfoVisualizer
+from streamdeck_sdk import logger
+
 
 class ExtraInfoStates(str, Enum):
     NONE = "None"
@@ -7,12 +10,53 @@ class ExtraInfoStates(str, Enum):
     SUBJECT = "Subject"
     BOTH = "Both"
 
-@dataclass
+
+@dataclass(init=False)
 class ContextData:
     account: str
     extra_info: ExtraInfoStates = ExtraInfoStates.NONE
     animated: bool = False
-    animation_index: int = 1
+    set_state_callback: callable
+    set_title_callback: callable
+    tile_visualizer: TileVisualizer
+
+    def __init__(
+        self,
+        account: str,
+        extra_info: ExtraInfoStates,
+        animated: bool,
+        set_state_callback: callable,
+        set_title_callback: callable,
+    ):
+        self.account = account
+        self.extra_info = extra_info
+        self.animated = animated
+        self.set_state_callback = set_state_callback
+        self.set_title_callback = set_title_callback
+        self.tile_visualizer = None
+
+        self.__post_init__()
+
+    def _update_tile_visualizer(self):
+        if self.tile_visualizer is not None:
+            self.tile_visualizer.stop()
+
+        if self.extra_info == ExtraInfoStates.NONE:
+            logger.debug(f"[{self.account}] Updating tile visualizer to SimpleVisualizer")
+            self.tile_visualizer = SimpleVisualizer(self.set_state_callback, self.set_title_callback)
+        else:
+            show_sender = self.extra_info in [ExtraInfoStates.SENDER, ExtraInfoStates.BOTH]
+            show_subject = self.extra_info in [ExtraInfoStates.SUBJECT, ExtraInfoStates.BOTH]
+            if not self.animated:
+                logger.debug(f"[{self.account}] Updating tile visualizer to ExtraInfoVisualizer")
+                self.tile_visualizer = ExtraInfoVisualizer(
+                    self.set_state_callback, self.set_title_callback, show_sender, show_subject
+                )
+            else:
+                logger.debug(f"[{self.account}] Updating tile visualizer to AnimatedExtraInfoVisualizer")
+                self.tile_visualizer = AnimatedExtraInfoVisualizer(
+                    self.set_state_callback, self.set_title_callback, show_sender, show_subject
+                )
 
     def __post_init__(self):
         if not isinstance(self.account, str) or not self.account:
@@ -21,5 +65,30 @@ class ContextData:
             raise ValueError("Extra info must be an instance of ExtraInfoStates")
         if not isinstance(self.animated, bool):
             raise ValueError("Animated must be a boolean")
-        if not isinstance(self.animation_index, int) or self.animation_index < 1:
-            raise ValueError("Animation index must be a positive integer")
+        if not callable(self.set_state_callback):
+            raise ValueError("Set state callback must be a callable")
+        if not callable(self.set_title_callback):
+            raise ValueError("Set title callback must be a callable")
+        self._update_tile_visualizer()
+
+    def set_extra_info(self, extra_info: ExtraInfoStates | str):
+        if extra_info is None or extra_info == "":
+            extra_info = ExtraInfoStates.NONE
+        if not isinstance(extra_info, ExtraInfoStates):
+            extra_info = ExtraInfoStates(extra_info)
+        if self.extra_info == extra_info:
+            return
+        self.extra_info = extra_info
+        self._update_tile_visualizer()
+
+    def set_animated(self, animated: bool | str):
+        logger.debug(f"[{self.account}] Received animated: {animated}")
+        if isinstance(animated, str) and animated.lower() == "false":
+            animated = False
+
+        animated = bool(animated)
+        if self.animated == animated:
+            return
+        logger.debug(f"[{self.account}] Setting animated to {animated}")
+        self.animated = animated
+        self._update_tile_visualizer()

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/code/mail_states.py
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/code/mail_states.py
@@ -1,0 +1,5 @@
+from enum import IntEnum
+
+class MailStates(IntEnum):
+    READ = 0
+    UNREAD = 1

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/code/main.py
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/code/main.py
@@ -1,30 +1,15 @@
 import settings
 import threading
-from enum import IntEnum, Enum
-from dataclasses import dataclass
+from enum import IntEnum
 
 from streamdeck_sdk import StreamDeck, Action, events_received_objs, logger, log_errors, in_separate_thread
 import win32com.client
+from context_data import ExtraInfoStates, ContextData
 
 
 class MailStates(IntEnum):
     READ = 0
     UNREAD = 1
-
-
-class ExtraInfoStates(str, Enum):
-    NONE = "None"
-    SENDER = "Sender"
-    SUBJECT = "Subject"
-    BOTH = "Both"
-
-
-@dataclass
-class ContextData:
-    account: str
-    extra_info: ExtraInfoStates
-    animated: bool = False
-    animation_index: int = 1
 
 
 class UnreadCounter(Action):

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/code/tile_visualizer.py
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/code/tile_visualizer.py
@@ -1,0 +1,190 @@
+from abc import ABC, abstractmethod
+import win32com.client
+from mail_states import MailStates
+from streamdeck_sdk import logger, log_errors
+import time
+import threading
+
+
+class TileVisualizer(ABC):
+
+    def __init__(self, set_state_callback: callable, set_title_callback: callable):
+        self.set_state_callback = set_state_callback
+        self.set_title_callback = set_title_callback
+
+    def set_state(self, state: MailStates) -> None:
+        self.set_state_callback(state)
+
+    def set_title(self, title: str) -> None:
+        self.set_title_callback(title)
+
+    def update_state(self, unread_count: int) -> None:
+        self.set_state(MailStates.UNREAD if unread_count > 0 else MailStates.READ)
+
+    @abstractmethod
+    def update_tile(self, folder: win32com.client.CDispatch) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
+class SimpleVisualizer(TileVisualizer):
+    def __init__(self, set_state_callback: callable, set_title_callback: callable):
+        super().__init__(set_state_callback, set_title_callback)
+
+    def update_tile(self, folder: win32com.client.CDispatch) -> None:
+        unread_count = folder.UnReadItemCount
+        self.update_state(unread_count)
+        self.set_title(f"{unread_count}")
+
+
+EXTRA_INFO_MAX_LENGTH = 9
+
+
+class ExtraInfoVisualizer(SimpleVisualizer):
+    def __init__(
+        self,
+        set_state_callback: callable,
+        set_title_callback: callable,
+        show_sender: bool,
+        show_subject: bool,
+    ):
+        super().__init__(set_state_callback, set_title_callback)
+        self.show_sender = show_sender
+        self.show_subject = show_subject
+
+    def update_tile(self, folder: win32com.client.CDispatch) -> None:
+        unread_count = folder.UnReadItemCount
+        if unread_count == 0:
+            super().update_tile(folder)
+        else:
+            self.set_state(MailStates.UNREAD)
+
+            last_unread_email = folder.Items.Restrict("[UnRead] = True").GetLast()
+            sender = last_unread_email.SenderName
+            subject = last_unread_email.Subject
+
+            extra_info = ""
+            if self.show_sender:
+                extra_info = self.get_extra_info_line(sender)
+
+            if self.show_subject:
+                if extra_info != "":
+                    extra_info += "\n"
+                subject_text = self.get_extra_info_line(subject)
+                extra_info += subject_text
+
+            title_content = f"{unread_count}" if extra_info == "" else f"{unread_count}\n{extra_info}"
+            self.set_title(title_content)
+
+    def get_extra_info_line(self, text: str):
+        logger.debug(f"get_extra_info_line: {text}")
+        return text[:EXTRA_INFO_MAX_LENGTH]
+
+
+class AnimatedExtraInfoVisualizer(ExtraInfoVisualizer):
+    class TileAnimation:
+        def __init__(self, set_title: callable, unread_count: int, sender: str, subject: str):
+            # TODO: Move it to single place with update interval
+            self.FIRST_FRAME_DURATION_SECONDS = 1
+            self.FRAME_DURATION_SECONDS = 0.5
+            self.MAX_FRAMES = 15
+            self.CHARACTERS_PER_FRAME = 2
+
+            self.set_title = set_title
+            self.unread_count = unread_count
+            self.sender = sender
+            self.subject = subject
+            self.animation_frame = 0
+            self.thread = None
+
+        def start(self):
+            logger.debug(f"start animation: {self.unread_count} {self.sender} {self.subject}")
+            self.thread = threading.Thread(target=self.animate)
+            self.thread.start()
+
+        @log_errors
+        def animate(self):
+            animation_index = 0
+            reached_end = False
+            while threading.current_thread() == self.thread and not reached_end and animation_index < self.MAX_FRAMES:
+                logger.debug(f"animation frame: {animation_index}")
+                reached_end = self.show_frame(animation_index)
+                animation_index = animation_index + 1
+                time.sleep(
+                    self.FIRST_FRAME_DURATION_SECONDS if animation_index == 0 else self.FRAME_DURATION_SECONDS
+                )
+            # After the animation is finished, show beginning of the extra info
+            _ = self.show_frame(0)
+
+        def get_line_for_frame(self, animation_frame: int, text: str) -> tuple[str, bool]:
+            """
+            Returns the line to show for the given animation frame.
+            If the end of the text is returned the second return value is True.
+            """
+            logger.debug(f"get_line_for_frame: {animation_frame} {text}")
+            if len(text) <= EXTRA_INFO_MAX_LENGTH:
+                return (text, True)
+
+            offset = max(
+                min(animation_frame * self.CHARACTERS_PER_FRAME, len(text) - EXTRA_INFO_MAX_LENGTH), 0
+            )
+            return (
+                text[offset : offset + EXTRA_INFO_MAX_LENGTH],
+                offset + EXTRA_INFO_MAX_LENGTH >= len(text),
+            )
+
+        def show_frame(self, animation_frame: int) -> bool:
+            """
+            Displays information for the given animation frame.
+            Returns True if the animation is finished.
+            """
+            sender_line, sender_reached_end = self.get_line_for_frame(animation_frame, self.sender)
+            subject_line, subject_reached_end = self.get_line_for_frame(animation_frame, self.subject)
+            title = f"{self.unread_count}"
+            if sender_line != "":
+                title += f"\n{sender_line}"
+            if subject_line != "":
+                title += f"\n{subject_line}"
+
+            self.set_title(title)
+            return sender_reached_end and subject_reached_end
+
+    def __init__(
+        self,
+        set_state_callback: callable,
+        set_title_callback: callable,
+        show_sender: bool,
+        show_subject: bool,
+    ):
+        super().__init__(set_state_callback, set_title_callback, show_sender, show_subject)
+        self.animation = None
+
+    def update_tile(self, folder: win32com.client.CDispatch) -> None:
+        unread_count = folder.UnReadItemCount
+        if unread_count == 0:
+            super().update_tile(folder)
+        else:
+            self.set_state(MailStates.UNREAD)
+            last_unread_email = folder.Items.Restrict("[UnRead] = True").GetLast()
+            sender = last_unread_email.SenderName
+            subject = last_unread_email.Subject
+            self.animation = self.TileAnimation(self.set_title, unread_count, sender, subject)
+            self.animation.start()
+
+    def get_extra_info_line(self, animation_frame: int, text: str):
+        logger.debug(f"get_extra_info_line: {animation_frame} {text}")
+        if len(text) <= EXTRA_INFO_MAX_LENGTH:
+            return text
+
+        offset = max(min(animation_frame * 2, len(text) - EXTRA_INFO_MAX_LENGTH), 0)
+        return (
+            text[offset : offset + EXTRA_INFO_MAX_LENGTH],
+            offset + EXTRA_INFO_MAX_LENGTH >= len(text),
+        )
+
+    def stop(self):
+        if self.animation is not None:
+            self.animation.thread = None
+            self.animation = None

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json
@@ -30,7 +30,7 @@
   "Description": "Windows Outlook unread messages counter.",
   "Icon": "assets/unread_counter/envelope_open_icon",
   "Name": "Outlook Unread Counter",
-  "Version": "0.0.90",
+  "Version": "0.0.94",
   "SDKVersion": 2,
   "OS": [
     {

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json
@@ -30,7 +30,7 @@
   "Description": "Windows Outlook unread messages counter.",
   "Icon": "assets/unread_counter/envelope_open_icon",
   "Name": "Outlook Unread Counter",
-  "Version": "0.0.97",
+  "Version": "0.0.135",
   "SDKVersion": 2,
   "OS": [
     {

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/manifest.json
@@ -30,7 +30,7 @@
   "Description": "Windows Outlook unread messages counter.",
   "Icon": "assets/unread_counter/envelope_open_icon",
   "Name": "Outlook Unread Counter",
-  "Version": "0.0.94",
+  "Version": "0.0.97",
   "SDKVersion": 2,
   "OS": [
     {

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/property_inspector/unread_counter_pi.html
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/property_inspector/unread_counter_pi.html
@@ -19,10 +19,24 @@
         <select class="sdpi-item-value" id="account" setting="account" placeholder="Choose account" onchange="account_changed()">
         </select>
     </div>
+
     <div class="sdpi-item" label="Extra info content">
         <div class="sdpi-item-label">Include extra information</div>
         <select class="sdpi-item-value" id="extra_info" setting="extra_info" placeholder="Choose extra info" onchange="extra_info_changed()">
         </select>
+    </div>
+
+    <div type="checkbox" class="sdpi-item">
+        <div class="sdpi-item-label">Animate Extra Info</div>
+        <div class="sdpi-item-value">
+            <div class="sdpi-item-child">
+                <input class="sdpi-item-value" id="animate_extra_info" type="checkbox" onchange="animate_changed()" 
+                     >
+                <label for="animate_extra_info" class="sdpi-item-label">
+                    <span></span>
+                </label>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -44,9 +58,11 @@
     const ACCOUNTS_KEY = 'accounts'
     const EXTRA_INFO_KEY = 'extra_info'
     const EXTRA_INFO_STATES_KEY = 'extra_info_states'
+    const ANIMATE_EXTRA_INFO_KEY = 'animate_extra_info'
 
     const account_el = document.getElementById(ACCOUNT_KEY)
     const extra_info_el = document.getElementById(EXTRA_INFO_KEY)
+    const animate_extra_info_el = document.getElementById(ANIMATE_EXTRA_INFO_KEY)
 
     function account_changed() {
         console.log('account_changed', account_el.value);
@@ -57,6 +73,12 @@
     function extra_info_changed() {
         console.log('extra_info_changed', extra_info_el.value);
         settings[EXTRA_INFO_KEY] = extra_info_el.value
+        $PI.setSettings(settings);
+    }
+
+    function animate_changed() {
+        console.log('animate_changed', animate_extra_info_el.checked);
+        settings[ANIMATE_EXTRA_INFO_KEY] = animate_extra_info_el.checked
         $PI.setSettings(settings);
     }
 
@@ -75,6 +97,12 @@
         {
             update_select_options(extra_info_el, extra_info_options, extra_info_selected)
         }
+
+        let animate_extra_info_checked = settings[ANIMATE_EXTRA_INFO_KEY]
+        if (animate_extra_info_checked !== undefined)
+        {
+            animate_extra_info_el.checked = animate_extra_info_checked
+        }
     }
 
     account_el.addEventListener('change', () => {
@@ -85,6 +113,11 @@
     extra_info_el.addEventListener('change', () => {
         console.log('extra_info_el.value changed', extra_info_el.value);
         extra_info_changed();
+    });
+
+    animate_extra_info_el.addEventListener('change', () => {
+        console.log('animate_extra_info_el.checked changed', animate_extra_info_el.checked);
+        animate_changed();
     });
 
     let settings

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/property_inspector/unread_counter_pi.py
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/property_inspector/unread_counter_pi.py
@@ -10,11 +10,27 @@ def main():
     pi = PropertyInspector(
         action_uuid="com.mcczarny.outlookunreadcounter.unreadcounter",
         elements=[
-            Message(
-                uid="my_message",
-                heading="Example message",
-                message_type=MessageTypes.INFO,
-                text="Example message text",
+            Select(
+                uid="account",
+                label="Outlook Account",
+                values=[""],
+                default_value="",
+            ),
+            Select(
+                    uid="extra_info",
+                    label="Include Extra Info",
+                    values=["None", "Subject", "Sender", "Both"],
+                    default_value="None",
+            ),
+            Checkbox(
+                label="Animate Extra Info",
+                items=[
+                    CheckboxItem(
+                        uid="animate_extra_info",
+                        label="on",
+                        checked=False,
+                    ),
+                ],
             ),
         ]
     )

--- a/com.mcczarny.outlookunreadcounter.sdPlugin/property_inspector/unreadcounter_pi.html
+++ b/com.mcczarny.outlookunreadcounter.sdPlugin/property_inspector/unreadcounter_pi.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport"
+          content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,minimal-ui,viewport-fit=cover"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
+    <title>com.mcczarny.outlookunreadcounter.unreadcounter Property Inspector</title>
+    <link rel="stylesheet" href="streamdeck-javascript-sdk/css/sdpi.css"/>
+</head>
+
+<body>
+<div class="sdpi-wrapper">
+
+        <div class="sdpi-item">
+        <div class="sdpi-item-label">Outlook Account</div>
+        <select class="sdpi-item-value select" id="account" onchange="onchange_account()">
+            <option value="null"></option>
+<option selected value=""></option>
+        </select>
+    </div>
+    <div class="sdpi-item">
+        <div class="sdpi-item-label">Include Extra Info</div>
+        <select class="sdpi-item-value select" id="extra_info" onchange="onchange_extra_info()">
+            <option value="null"></option>
+<option selected value="None">None</option>
+<option value="Subject">Subject</option>
+<option value="Sender">Sender</option>
+<option value="Both">Both</option>
+        </select>
+    </div>
+    <div type="checkbox" class="sdpi-item">
+        <div class="sdpi-item-label">Animate Extra Info</div>
+        <div class="sdpi-item-value">
+            <div class="sdpi-item-child">
+                <input class="sdpi-item-value" id="animate_extra_info" type="checkbox" onchange="onchange_animate_extra_info()" 
+                     >
+                <label for="animate_extra_info" class="sdpi-item-label">
+                    <span></span>on
+                </label>
+            </div>
+        </div>
+    </div>
+
+</div>
+
+<!-- Stream Deck Libs -->
+<script src="streamdeck-javascript-sdk/js/constants.js"></script>
+<script src="streamdeck-javascript-sdk/js/prototypes.js"></script>
+<script src="streamdeck-javascript-sdk/js/timers.js"></script>
+<script src="streamdeck-javascript-sdk/js/utils.js"></script>
+<script src="streamdeck-javascript-sdk/js/events.js"></script>
+<script src="streamdeck-javascript-sdk/js/api.js"></script>
+<script src="streamdeck-javascript-sdk/js/property-inspector.js"></script>
+<script src="streamdeck-javascript-sdk/js/dynamic-styles.js"></script>
+<script>
+    console.log('Property Inspector loaded', $PI);
+
+        const account_el = document.getElementById("account")
+    const extra_info_el = document.getElementById("extra_info")
+    const animate_extra_info_el = document.getElementById("animate_extra_info")
+
+    let settings
+
+    $PI.onConnected(jsn => {
+        console.log('Property Inspector connected', jsn);
+        console.log(jsn.actionInfo.payload.settings);
+        settings = jsn.actionInfo.payload.settings;
+
+                if (settings["account"] !== undefined) {
+            let update_result = update_select_options(
+                account_el,
+                settings["account"][0],
+                settings["account"][1],
+            )
+            if (!update_result) {
+                let values_and_selected = get_select_values_and_selected(
+                    account_el,
+                )
+                settings["account"] = [
+                    values_and_selected.values,
+                    values_and_selected.selected,
+                ]
+            }
+        } else {
+            let values_and_selected = get_select_values_and_selected(
+                account_el,
+            )
+            settings["account"] = [
+                values_and_selected.values,
+                values_and_selected.selected,
+            ]
+        }
+        if (settings["extra_info"] !== undefined) {
+            let update_result = update_select_options(
+                extra_info_el,
+                settings["extra_info"][0],
+                settings["extra_info"][1],
+            )
+            if (!update_result) {
+                let values_and_selected = get_select_values_and_selected(
+                    extra_info_el,
+                )
+                settings["extra_info"] = [
+                    values_and_selected.values,
+                    values_and_selected.selected,
+                ]
+            }
+        } else {
+            let values_and_selected = get_select_values_and_selected(
+                extra_info_el,
+            )
+            settings["extra_info"] = [
+                values_and_selected.values,
+                values_and_selected.selected,
+            ]
+        }
+        if (settings["animate_extra_info"] !== undefined) {
+            animate_extra_info_el.checked = settings.animate_extra_info
+        } else {
+            settings["animate_extra_info"] = animate_extra_info_el.checked
+        }
+
+        $PI.setSettings(settings);
+    });
+
+    $PI.onDidReceiveSettings("com.mcczarny.outlookunreadcounter.unreadcounter", jsn => {
+        settings = jsn.payload.settings
+
+                if (settings["account"] !== undefined) {
+            let update_result = update_select_options(
+                account_el,
+                settings["account"][0],
+                settings["account"][1],
+            )
+            if (!update_result) {
+                let values_and_selected = get_select_values_and_selected(
+                    account_el,
+                )
+                settings["account"] = [
+                    values_and_selected.values,
+                    values_and_selected.selected,
+                ]
+            }
+        } else {
+            let values_and_selected = get_select_values_and_selected(
+                account_el,
+            )
+            settings["account"] = [
+                values_and_selected.values,
+                values_and_selected.selected,
+            ]
+        }
+        if (settings["extra_info"] !== undefined) {
+            let update_result = update_select_options(
+                extra_info_el,
+                settings["extra_info"][0],
+                settings["extra_info"][1],
+            )
+            if (!update_result) {
+                let values_and_selected = get_select_values_and_selected(
+                    extra_info_el,
+                )
+                settings["extra_info"] = [
+                    values_and_selected.values,
+                    values_and_selected.selected,
+                ]
+            }
+        } else {
+            let values_and_selected = get_select_values_and_selected(
+                extra_info_el,
+            )
+            settings["extra_info"] = [
+                values_and_selected.values,
+                values_and_selected.selected,
+            ]
+        }
+        if (settings["animate_extra_info"] !== undefined) {
+            animate_extra_info_el.checked = settings.animate_extra_info
+        } else {
+            settings["animate_extra_info"] = animate_extra_info_el.checked
+        }
+    });
+
+        const onchange_account = () => {
+        console.log(account_el.value);
+        let values_and_selected = get_select_values_and_selected(
+            account_el,
+        )
+        settings["account"] = [
+            values_and_selected.values,
+            values_and_selected.selected,
+        ]
+        $PI.setSettings(settings);
+    }
+    const onchange_extra_info = () => {
+        console.log(extra_info_el.value);
+        let values_and_selected = get_select_values_and_selected(
+            extra_info_el,
+        )
+        settings["extra_info"] = [
+            values_and_selected.values,
+            values_and_selected.selected,
+        ]
+        $PI.setSettings(settings);
+    }
+    const onchange_animate_extra_info = () => {
+        console.log(animate_extra_info_el.checked);
+        settings["animate_extra_info"] = animate_extra_info_el.checked
+        $PI.setSettings(settings);
+    }
+
+    function get_select_values_and_selected(element) {
+        let values = [];
+        for (let i = 0; i < element.options.length; i++) {
+            let option = element.options[i];
+            if (option.value === "null") {
+                continue;
+            }
+            values.push(option.value);
+        }
+        let selected
+        if (element.value === "null") {
+            selected = null
+        } else {
+            selected = element.value
+        }
+        return {
+            values: values,
+            selected: selected
+        };
+    }
+
+    function update_select_options(element, values, selected_value) {
+        element.innerHTML = '';
+
+        if (selected_value === null) {
+            selected_value = "null";
+        }
+
+        const nullOption = document.createElement('option');
+        nullOption.value = "null";
+        nullOption.text = "";
+        element.appendChild(nullOption);
+
+        values.forEach(value => {
+            if (value === null) {
+                return;
+            }
+            const option = document.createElement('option');
+            option.value = value;
+            option.text = value;
+            element.appendChild(option);
+        });
+
+        if (values.includes(selected_value)) {
+            element.value = selected_value;
+            return true
+        } else {
+            element.value = "null";
+            return false
+        }
+    }
+
+</script>
+</body>
+
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+
+[project]
+name = "Outlook Unread Counter"
+authors = [
+    { name = "Maciej Czarnecki", email = "mcczarny@gmail.com" },
+]
+description = "Stream deck plugin showing Windows Outlook unread messages counter."
+readme = "README.md"
+
+[project.urls]
+"Homepage" = "https://github.com/McCzarny/OutlookUnreadCounter"
+
+[tool.black]
+line-length = 110


### PR DESCRIPTION
A stream deck tile is quite small so does not allow to display a lot of text. As a workaround the plugin can do a pan animation through the text. For now it will be a constant animation with 15 frames with 2 characters offset for each character. It should allow to show about `9 + 14 * 2 = 37` characters.
resolves #4 